### PR TITLE
swoopyBootstrap: add annotations by clicking and dragging

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,9 @@ Usage: `swoopyBootstrap.sel(swoopySel)`
 Pass in a function to set the label text.
 
 Usage: `swoopyBootstrap.labelAccessor(function(d, i) { return "Hello, world!" })`
+
+#### swoopyBootstrap.container([DOM Node])
+
+Explicitly set the DOM node which will be used to determine the offset for mouse events. If you are setting transforms on the elements you want to annotate, you will likely need to use this or your annotations may show up in a place other than where you intended. 
+
+Usage: `swoopyBootstrap.container(swoopySel.node())`

--- a/README.md
+++ b/README.md
@@ -31,3 +31,33 @@ Array of objects representing annotations. The `path` in each annotations will h
 #### swoopyDrag.on('drag', [function])
 
 Called as the labels or paths are dragged.
+
+#### swoopyDrag.bootstrap()
+
+Creates a new `swoopyBootstrap`.
+
+Usage: 
+
+    var swoopyBootstrap = swoopyDrag.bootstrap()
+      .scale({x: myXScale, y: myYScale})
+      .sel(swoopySel)
+      .labelAccessor(function(d, i) { return "Hello, world!" })
+    someD3Selection.call(swoopyBootstrap)
+
+#### swoopyBootstrap.scale([object])
+
+Set the scales for the bootstrap function to use.
+
+Usage: `swoopyBootstrap.scale({x: myXScale, y: myYScale})`
+
+#### swoopyBootstrap.sel([object])
+
+Point bootstrap to the D3 selection you are using for annotations.
+
+Usage: `swoopyBootstrap.sel(swoopySel)`
+
+#### swoopyBootstrap.labelAccessor([function])
+
+Pass in a function to set the label text.
+
+Usage: `swoopyBootstrap.labelAccessor(function(d, i) { return "Hello, world!" })`

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@ svg{
 
 text {
   font-size: 12px;
-  text-shadow: 0 1px 0 #fff, 1px 0 0 #fff, 0 -1px 0 #fff, -1px 0 0 #fff;
+  text-shadow: 0 1px 0 #F5F5F5, 1px 0 0 #F5F5F5, 0 -1px 0 #F5F5F5, -1px 0 0 #F5F5F5;
 }
 
 .axis line, .axis path {
@@ -74,7 +74,7 @@ div.tooltip {
 #annotations-update{
   display: block;
   float: right;
-  width: 380px;
+  width: 500px;
   position: relative;
   top: -25px;
   left: -120px;
@@ -114,7 +114,12 @@ p, pre{
   margin-bottom: 30px;
 }
 
-
+#graphcontainer {
+  padding-top: 20px; 
+  padding-bottom: 15px; 
+  overflow: auto; 
+  width: 1000px;
+}
 
 #resizable {
   position: relative;
@@ -144,26 +149,26 @@ a{
 <body>
 
 <h1><a href='https://github.com/1wheel/swoopy-drag'>swoopyDrag.js</a></h1>
-<h3>Artisanal label placement for d3 graphics. </h3>
+<h3 style='margin-bottom: 50px;'>Artisanal label placement for d3 graphics</h3>
 
 <p>
-  <i>“The annotation layer is the most important thing we do”</i> -Amanda Cox
+  <i>“The annotation layer is the most important thing we do”</i> —Amanda Cox
 </p>
 <p>
-  <span class='mono'>swoopyDrag</span> helps you hand place annotations on d3 graphics. It takes an array of objects representing annotations and turns them into arrows and labels. Drag the text and control circles below to update the annotations array.
+  <span class='mono'>swoopyDrag</span> helps you hand place annotations on d3 graphics. It takes an array of objects representing annotations and turns them into lines and labels. Drag the text and control circles below to update the annotations array:
 </p>
 <p>
   New! Click and drag from any point to create a new annotation with <a href="#bootstrap">bootstrap</a>.
 </p>
 
-<div style='padding-top: 20px; padding-bottom: 15px;'>
+<div id='graphcontainer'>
   <div id='graph'>
   </div>
   <div id='annotations-update'></div>
 </div>
 
 <p>
-The <span class='mono'>x</span> and <span class='mono'>y</span> functions are called on each annotation to determine its position. The array of annoations are passed in through <m>annotations</m>. Setting <m>draggable</m> to <m>true</m> adds control points to the path strings and enables label dragging - turn on while developing and off when you're ready to publish.
+The <span class='mono'>x</span> and <span class='mono'>y</span> functions are called on each annotation to determine its position. Setting <m>draggable</m> to <m>true</m> adds control points to the path strings and enables label dragging - turn on while developing and off when you're ready to publish.
 
 <pre>
 var swoopy = d3.swoopyDrag()
@@ -174,11 +179,11 @@ var swoopy = d3.swoopyDrag()
 </pre>
 
 <p>
-The shape of each annotation's line is determined by the <span class='mono'>path</span> property (only <a href='http://roadtolarissa.com/blog/2015/02/22/svg-path-strings/'>straight lines</a> and <a href='https://www.w3.org/TR/SVG/paths.html#PathDataQuadraticBezierCommands'>béziers</a> are currently supported), the string of text by the <span class='mono'>text</span> property and the position of the text by the <span class='mono'>testOffset</span> property.
 
+The shape of each annotation's line is determined by the <span class='mono'>path</span> property, the text by the <span class='mono'>text</span> property and the position of the text by the <span class='mono'>testOffset</span> property. Currently only <a href='https://www.w3.org/TR/SVG/paths.html#PathDataLinetoCommands'>straight paths</a> (paths of the form <m>M 0,0 L 10,10</m>) and <a href='https://www.w3.org/TR/SVG/paths.html#PathDataQuadraticBezierCommands'>béziers</a> (paths of the form <m>M 0,0 C 10,10 10,15, 20,15</m>) are supported—see my interactive path string <a href='http://roadtolarissa.com/blog/2015/02/22/svg-path-strings/'>tutorial</a> for more.
 </p>
 
-<p> The annotations are added to page just like <m>d3.svg.axis</m> - appened a new <m>group</m> element and use <m>call</m>:
+<p> The annotations are added to the page just like <m>d3.svg.axis</m> - append a new <m>group</m> element and use <m>call</m>:
 </p>
 
 <pre>
@@ -194,7 +199,7 @@ var swoopySel = svg.append('g').call(swoopy)
   <div class="resizer"></div>
 </div>
 
-<p> Since each annotation's position is determined primary by scales, lines and labels will still point to the correct position when the chart size changes. As the chart shrinks though, the annotations might overlap or cover up data points. To show fewer or differently positioned notes on mobile, you could create multiple annotation arrays for different screen sizes: 
+<p> Since each annotation's position is determined primarily by scales, lines and labels will still point to the correct position when the chart size changes. As the chart shrinks though, the annotations might overlap or cover up data points. To show fewer or differently positioned labels on mobile, you could create multiple annotation arrays for different screen sizes: 
 </p>
 
 <pre>
@@ -329,8 +334,8 @@ var annotations = [
   {
     "xVal": 3.8,
     "yVal": 7.7,
-    "path": "M-100,-47C-116,-12,-39,12,-8,-16",
-    "text": "Vigrinica",
+    "path": "M-100,-47C-116,-12,-46,25,-8,-16",
+    "text": "Virginica",
     "textOffset": [
       -98,
       -49
@@ -339,7 +344,7 @@ var annotations = [
   {
     "xVal": 2.3,
     "yVal": 5,
-    "path": "M-5,86C-64,71,-56,25,-11,6",
+    "path": "M-5,86C-47,82,-55,18,-9,4",
     "text": "Versicolor",
     "textOffset": [
       -2,
@@ -395,19 +400,6 @@ d3.tsv('lib/data.tsv', function(res){
       .attr('fill', ƒ('species', c.color))
       .attr({r: 5, stroke: '#000'})
    //   .call(d3.attachTooltip)
-
-  // var legend = c.svg.dataAppend(c.color.domain(), 'g.legend')
-  //     .translate(function(d, i){ return [0, i*20] })
-
-  // legend.append('rect')
-  //     .attr({x: c.width - 18, width: 18, height: 18})
-  //     .style('fill', c.color)
-
-  // legend.append('text')
-  //     .attr({x: c.width - 24, y: 9, dy: '.33em', 'text-anchor': 'end'})
-  //     .text(ƒ())
-
-
 
   var swoopySel = c.svg.append('g.annotations')
       .call(swoopy)
@@ -494,7 +486,7 @@ d3.tsv('lib/data.tsv', function(res){
     })
 
     d3.timer(function(){
-      if (+lastScroll < +new Date() - 600) return
+      if (lastScroll < new Date() - 600) return
 
       var min = 400
       var max = 800
@@ -504,6 +496,16 @@ d3.tsv('lib/data.tsv', function(res){
       if (curX > max) isGrowing = false
 
       var step = Math.max(1, Math.abs(600))
+
+      setWidth(curX + (isGrowing ? 1 : -1)*5) 
+    })
+
+  })()
+
+})
+
+
+</script>ep = Math.max(1, Math.abs(600))
 
       setWidth(curX + (isGrowing ? 1 : -1)*5) 
     })

--- a/index.html
+++ b/index.html
@@ -65,17 +65,20 @@ div.tooltip {
 
 
 #graph{
-  display: inline-block;
+  display: block;
+  float: left;
   width: 500px;
-  position: relative;
   z-index: 2;
+  top: 0;
 }
 #annotations-update{
-  display: inline-block;
+  display: block;
+  float: right;
   width: 380px;
   position: relative;
   top: -25px;
   left: -120px;
+  z-index: -1;
   /*background: #eee;*/
 }
 
@@ -148,6 +151,9 @@ a{
 </p>
 <p>
   <span class='mono'>swoopyDrag</span> helps you hand place annotations on d3 graphics. It takes an array of objects representing annotations and turns them into arrows and labels. Drag the text and control circles below to update the annotations array.
+</p>
+<p>
+  New! Click and drag from any point to create a new annotation with <a href="#bootstrap">bootstrap</a>.
 </p>
 
 <div style='padding-top: 20px; padding-bottom: 15px;'>
@@ -249,6 +255,25 @@ swoopySel.selectAll('text')
 Since the annotations are made up of selectable <m>path</m> and <m>group</m> elements, they can be styled differently. 
 
 
+
+<h3 id="bootstrap">Bootstrap your annotations</h3>
+
+<p>Bootstrap lets you add annotations by clicking and dragging.</p>
+
+<pre>
+var swoopyBootstrap = swoopy.bootstrap()
+  .sel(swoopySel)                        // your d3 selection for swoopy annotations
+  .labelAccessor(ƒ('species'))           // this function sets label text
+  .scale({x: yourXScale, y: yourYScale}) // your x and y scales
+
+d3.selectAll('rect')
+  .data(yourData).enter()
+  ...
+  .call(swoopyBootstrap)
+</pre>
+
+
+
 <h3>Examples</h3>
 <p style='line-height: 2.8em;'>
 <a href='http://roadtolarissa.com/nba-minutes/'>Minute by Minute Point Differentials</a>
@@ -304,7 +329,7 @@ var annotations = [
   {
     "xVal": 3.8,
     "yVal": 7.7,
-    "path": "M-100,-47C-116,-12,-46,25,-8,-16",
+    "path": "M-100,-47C-116,-12,-39,12,-8,-16",
     "text": "Vigrinica",
     "textOffset": [
       -98,
@@ -345,6 +370,15 @@ var swoopy = d3.swoopyDrag()
       annotationText.text('var annotations = ' + JSON.stringify(annotations, null, 2))
     })
 
+var swoopy2 = d3.swoopyDrag()
+    .draggable(true)
+    .x(ƒ('xVal', c.x))
+    .y(ƒ('yVal', c.y))
+    .annotations(annotations)
+    .on('drag', function(){
+      annotationText.text('var annotations = ' + JSON.stringify(annotations, null, 2))
+    })
+
 var annotationText = d3.select('#annotations-update').append('pre')
 
 
@@ -355,12 +389,12 @@ d3.tsv('lib/data.tsv', function(res){
   c.y.domain(d3.extent(data, ƒ('sepalLength'))).nice()
   c.drawAxis()
 
-  c.svg.dataAppend(data, 'circle')
+  var circs = c.svg.dataAppend(data, 'circle')
       .attr('cx', ƒ('sepalWidth', c.x))
       .attr('cy', ƒ('sepalLength', c.y))
       .attr('fill', ƒ('species', c.color))
       .attr({r: 5, stroke: '#000'})
-      .call(d3.attachTooltip)
+   //   .call(d3.attachTooltip)
 
   // var legend = c.svg.dataAppend(c.color.domain(), 'g.legend')
   //     .translate(function(d, i){ return [0, i*20] })
@@ -378,6 +412,12 @@ d3.tsv('lib/data.tsv', function(res){
   var swoopySel = c.svg.append('g.annotations')
       .call(swoopy)
 
+  var bootstrap = swoopy.bootstrap()
+      .sel(swoopySel)
+      .labelAccessor(ƒ('species'))
+      .scale({x: c.x, y: c.y})
+
+  circs.call(bootstrap)
   swoopySel.selectAll('path')
       .attr('marker-end', 'url(#arrow)')
 
@@ -408,6 +448,12 @@ d3.tsv('lib/data.tsv', function(res){
     r.y.domain(d3.extent(data, ƒ('sepalLength'))).nice()
     r.drawAxis()
 
+    
+
+    swoopy2.draggable(false).annotations(annotations.concat(dragToResize))
+    var swoopySel = r.svg.append('g.annotations').call(swoopy2)
+
+    
     var circles = r.svg.dataAppend(data, 'circle')
         .attr('cx', ƒ('sepalWidth', r.x))
         .attr('cy', ƒ('sepalLength', r.y))
@@ -416,14 +462,10 @@ d3.tsv('lib/data.tsv', function(res){
         .call(d3.attachTooltip)
 
 
-    swoopy.draggable(false).annotations(annotations.concat(dragToResize))
-    var swoopySel = r.svg.append('g.annotations').call(swoopy)
-
     swoopySel.selectAll('path')
         .attr('marker-end', 'url(#arrow)')
 
     swoopySel.selectAll('text').style('fill', 'black')
-
 
     resizer.call(d3.behavior.drag().on('drag', function(){
       setWidth(d3.mouse(this.parentNode)[0])

--- a/index.html
+++ b/index.html
@@ -139,6 +139,10 @@ p, pre{
   cursor: pointer;
 }
 
+.new {
+  background: papayawhip;
+}
+
 a{
   color: black;
 }
@@ -148,8 +152,13 @@ a{
 
 <body>
 
-<h1><a href='https://github.com/1wheel/swoopy-drag'>swoopyDrag.js</a></h1>
+<h1><a href='https://github.com/jmuyskens/swoopy-drag'>swoopyDrag.js</a></h1>
+
 <h3 style='margin-bottom: 50px;'>Artisanal label placement for d3 graphics</h3>
+
+<p>
+  <i>A fork of 1wheel's original <a href='https://github.com/1wheel/swoopy-drag'>swoopyDrag.js</a></i>
+</p>
 
 <p>
   <i>“The annotation layer is the most important thing we do”</i> —Amanda Cox
@@ -158,7 +167,7 @@ a{
   <span class='mono'>swoopyDrag</span> helps you hand place annotations on d3 graphics. It takes an array of objects representing annotations and turns them into lines and labels. Drag the text and control circles below to update the annotations array:
 </p>
 <p>
-  New! Click and drag from any point to create a new annotation with <a href="#bootstrap">bootstrap</a>.
+  <span class="new">New! Click and drag from any point to create a new annotation with <a href="#bootstrap">bootstrap</a>.</span>
 </p>
 
 <div id='graphcontainer'>

--- a/swoopy-drag.js
+++ b/swoopy-drag.js
@@ -119,21 +119,24 @@ d3.swoopyDrag = function(){
     var bootstrapOriginCoords
     var sel
     var labelAccessor = ƒ('key')
+    var container
     var scale = {
       x: null,
       y: null
     }
     var drag = d3.behavior.drag()
       .on('dragstart', function(d) {
-        bootstrapOriginCoords = d3.mouse(this);
+
+        bootstrapOriginCoords = d3.mouse(container ? container : this);
         d3.event.sourceEvent.stopPropagation();
       })
       .on('dragend', function(d) {
         d3.event.sourceEvent.stopPropagation();
-        var coords = d3.mouse(this);
+        console.log(d3.event);
+        var coords = d3.mouse(container ? container : this);
         var xDiff = coords[0] - bootstrapOriginCoords[0];
         var yDiff = coords[1] - bootstrapOriginCoords[1];
-        console.log(annotations)
+        console.log(scale.x.domain(), scale.x.range(), bootstrapOriginCoords[0], scale.x.invert(bootstrapOriginCoords[0]))
         annotations.push({
           'xVal': scale.x.invert(bootstrapOriginCoords[0]),
           'yVal': scale.y.invert(bootstrapOriginCoords[1]),
@@ -144,6 +147,12 @@ d3.swoopyDrag = function(){
         })
         self(sel);
       });
+
+      drag.container = function(_x) {
+        if (typeof(_x) == 'undefined') return container
+        container = _x
+        return drag
+      }
 
       drag.scale = function(_x) {
         if (typeof(_x) == 'undefined') return scale


### PR DESCRIPTION
I've been playing with swoopyDrag and I realized that adding annotations could be made as easy as swoopyDrag makes moving them around. 
![swoopybootstrapsm](https://cloud.githubusercontent.com/assets/1753996/14062824/bb92a922-f383-11e5-86af-b2504515fa50.gif)

So here's my proposal for a function that lets you bootstrap your annotations by dragging from your D3 SVG shapes. Be aware that some stuff in my `index.html` is [specific to my fork](https://github.com/1wheel/swoopy-drag/compare/master...jmuyskens:master#diff-eacf331f0ffc35d4b482f1d15a887d3bR155).

_from the README:_
#### swoopyDrag.bootstrap()

Creates a new `swoopyBootstrap`.

Usage: 

```
var swoopyBootstrap = swoopyDrag.bootstrap()
  .scale({x: myXScale, y: myYScale})
  .sel(swoopySel)
  .labelAccessor(function(d, i) { return "Hello, world!" })
someD3Selection.call(swoopyBootstrap)
```
#### swoopyBootstrap.scale([object])

Set the scales for the bootstrap function to use.

Usage: `swoopyBootstrap.scale({x: myXScale, y: myYScale})`
#### swoopyBootstrap.sel([object])

Point bootstrap to the D3 selection you are using for annotations.

Usage: `swoopyBootstrap.sel(swoopySel)`
#### swoopyBootstrap.labelAccessor([function])

Pass in a function to set the label text.

Usage: `swoopyBootstrap.labelAccessor(function(d, i) { return "Hello, world!" })`
