### PR TITLE
add optional css class property to annotations

### DIFF
--- a/index.html
+++ b/index.html
@@ -301,9 +301,10 @@ var annotations = [
     "sepalLength": 5.7,
     "path": "M-49,-61L-6,-8",
     "text": "Setosa",
+    "class": "highlight-label",
     "textOffset": [
-      -83,
-      -65
+      -70,
+      -75
     ]
   },
   {
@@ -391,6 +392,9 @@ d3.tsv('lib/data.tsv', function(res){
 
   swoopySel.selectAll('path')
       .attr('marker-end', 'url(#arrow)')
+
+  swoopySel.selectAll('.highlight-label text')
+      .attr('font-weight','bold');
 
   // swoopySel.selectAll('text')
   //     .each(function(d){

--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ export function swoopyDrag(){
     annotationSel = sel.html('').selectAll('g')
         .data(annotations).enter()
       .append('g')
+        .attr('class', function(d) { return d.class })
         .call(translate, function(d){ return [x(d), y(d)] })
 
     var textSel = annotationSel.append('text')

--- a/swoopy-drag.js
+++ b/swoopy-drag.js
@@ -55,6 +55,7 @@
       annotationSel = sel.html('').selectAll('g')
           .data(annotations).enter()
         .append('g')
+          .attr('class', function(d) { return d.class })
           .call(translate, function(d){ return [x(d), y(d)] })
 
       var textSel = annotationSel.append('text')


### PR DESCRIPTION
Hi Adam,

@cmcenaney and I propose adding an optional `class` property to the annotations object that, when present, is added to the annotation's grouping `<g>` element.

In the demo, I set the class of the first annotation, `Setosa`, to `highlight-label` and use a D3 selection to later make the text bold. `swoopySel.selectAll('.highlight-label text').attr('font-weight','bold');`

What do you think?